### PR TITLE
Update Docker base layer to use Go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.9
+FROM golang:1.13.7-alpine3.11
 WORKDIR /go/src/github.com/suyashkumar/ssl-proxy
 RUN apk add --no-cache make git zip
 RUN go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
This updates the Docker image to use Go 1.13.7, as Go 1.13+ is now required after #22. The GitHub actions CI was already using Go 1.13 so this was not caught there. If we will continue to maintain a Docker image to build ssl-proxy, some work should go into testing this docker build using GitHub actions as well! 

Separately, we should investigate building against Go 1.14. 

This closes #25. 