### PR TITLE
Switch golang base image to Debian in order to address libc linking p…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:1.13.7-alpine3.11
+FROM golang:1.13.15-buster
 WORKDIR /go/src/github.com/suyashkumar/ssl-proxy
-RUN apk add --no-cache make git zip
+RUN apt-get update \
+ && apt-get -y install zip \
+ && apt-get -y clean \
+ && rm -Rf /var/lib/apt/lists/*
 RUN go get -u github.com/golang/dep/cmd/dep
 COPY . .
 RUN make 


### PR DESCRIPTION
…roblem

Alpine has subistituted GNU libc with musl in 2014
(see https://www.alpinelinux.org/posts/Alpine-Linux-has-switched-to-musl-libc.html)

So if one builds ssl-proxy on Alpine, the linux binary will contain a reference to
the musl library. Since this library is not present in major linux distributions
(like Debian), launching ssl-proxy results in a "No such file or directory" error.
For more details on this problem see e.g.
https://www.reddit.com/r/golang/comments/64lz0s/how_to_crosscompile_libc_variants_like_musl/
https://stackoverflow.com/questions/54524785/how-to-build-a-go-executable-that-doesnt-link-to-musl-libc

Therefore the golang base image is switched from the Alpine to the Debian variant,
using it's most recent image of the 1.13 version line.