### PR TITLE
Update to Go 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.21
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.21
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18.3-alpine
 WORKDIR /go/src/github.com/suyashkumar/ssl-proxy
 RUN apk add --no-cache make git zip
-RUN go get -u github.com/golang/dep/cmd/dep
 COPY . .
+RUN go get -u github.com/golang/dep/cmd/dep
 RUN make 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/suyashkumar/ssl-proxy
 
-go 1.18
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -32,11 +32,6 @@ func newDirector(target *url.URL, extraDirector func(*http.Request)) func(*http.
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
-        if req.Header.Get("User-Agent") != "" {
-			// explicitly disable User-Agent so it's not set to default value
-			req.Header.Set("User-Agent", "")
-		}
-
 		if extraDirector != nil {
 			extraDirector(req)
 		}

--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -32,7 +32,7 @@ func newDirector(target *url.URL, extraDirector func(*http.Request)) func(*http.
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
-		if _, ok := req.Header["User-Agent"]; !ok {
+        if req.Header.Get("User-Agent") != "" {
 			// explicitly disable User-Agent so it's not set to default value
 			req.Header.Set("User-Agent", "")
 		}


### PR DESCRIPTION
As go 1.19 has reached End of Life, I propose we update to go 1.21.

This PR changes the version in the `.mod` file 1 line to make tests pass. The patch was done by marsam in the nixpkgs repository: https://github.com/NixOS/nixpkgs/pull/282237
I also successfully proxied my website, so it seems there are no breaking changes. What other testing needs to be done?